### PR TITLE
Bailing, prefix arguments, and command cycling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,11 @@ Since `evil-god-state` includes an indicator in the mode-line, you may want to u
 (add-hook 'evil-god-stop-hook (lambda () (diminish-undo 'god-local-mode)))
 ```
 
+It's handy to be able to abort a `evil-god-state' command.  The following will make the <ESC> key unconditionally exit evil-god-state.
+
+```lisp
+(evil-define-key 'god global-map [escape] 'evil-god-state-bail)
+```
+
 [evil-mode]: https://gitorious.org/evil/
 [god-mode]: https://github.com/chrisdone/god-mode

--- a/evil-god-state.el
+++ b/evil-god-state.el
@@ -66,6 +66,12 @@
 
 (defvar evil-execute-in-god-state-buffer nil)
 
+(defvar evil-god-last-command nil)
+
+(defun evil-god-fix-last-command ()
+  "Change `last-command' to be the command before `evil-execute-in-god-state'."
+  (setq last-command evil-god-last-command))
+
 (defun evil-stop-execute-in-god-state ()
   "Switch back to previous evil state."
   (when (and (not (eq this-command #'evil-execute-in-god-state))
@@ -76,6 +82,7 @@
              (not (eq this-command #'digit-argument))
              (not (eq this-command #'negative-argument))
              (not (minibufferp)))
+    (remove-hook 'pre-command-hook 'evil-god-fix-last-command)
     (remove-hook 'post-command-hook 'evil-stop-execute-in-god-state)
     (when (buffer-live-p evil-execute-in-god-state-buffer)
       (with-current-buffer evil-execute-in-god-state-buffer
@@ -91,8 +98,10 @@
 (defun evil-execute-in-god-state ()
   "Execute the next command in God state."
   (interactive)
+  (add-hook 'pre-command-hook #'evil-god-fix-last-command t)
   (add-hook 'post-command-hook #'evil-stop-execute-in-god-state t)
   (setq evil-execute-in-god-state-buffer (current-buffer))
+  (setq evil-god-last-command last-command)
   (cond
    ((evil-visual-state-p)
     (let ((mrk (mark))

--- a/evil-god-state.el
+++ b/evil-god-state.el
@@ -98,5 +98,14 @@
     (evil-god-state)))
   (evil-echo "Switched to God state for the next command ..."))
 
+;;; Pressing <esc> will always get you out of Evil-God state.
+(defun evil-god-state-bail ()
+  "Stop current God command and exit God state."
+  (interactive)
+  (evil-stop-execute-in-god-state)
+  (evil-god-stop-hook)
+  (evil-normal-state))
+(evil-define-key 'god global-map [escape] 'evil-god-state-bail)
+
 (provide 'evil-god-state)
 ;;; evil-god-state.el ends here

--- a/evil-god-state.el
+++ b/evil-god-state.el
@@ -69,6 +69,12 @@
 (defun evil-stop-execute-in-god-state ()
   "Switch back to previous evil state."
   (when (and (not (eq this-command #'evil-execute-in-god-state))
+             (not (eq this-command #'universal-argument))
+             (not (eq this-command #'universal-argument-minus))
+             (not (eq this-command #'universal-argument-more))
+             (not (eq this-command #'universal-argument-other-key))
+             (not (eq this-command #'digit-argument))
+             (not (eq this-command #'negative-argument))
              (not (minibufferp)))
     (remove-hook 'post-command-hook 'evil-stop-execute-in-god-state)
     (when (buffer-live-p evil-execute-in-god-state-buffer)

--- a/evil-god-state.el
+++ b/evil-god-state.el
@@ -42,6 +42,10 @@
 ;;     (add-hook 'evil-god-start-hook (lambda () (diminish 'god-local-mode)))
 ;;     (add-hook 'evil-god-stop-hook (lambda () (diminish-undo 'god-local-mode)))
 
+;; It's handy to be able to abort a `evil-god-state' command.  The following
+;; will make the <ESC> key unconditionally exit evil-god-state.
+;;     (evil-define-key 'god global-map [escape] 'evil-god-state-bail)
+
 
 ;;; Code:
 (require 'evil)
@@ -113,14 +117,13 @@
     (evil-god-state)))
   (evil-echo "Switched to God state for the next command ..."))
 
-;;; Pressing <esc> will always get you out of Evil-God state.
+;;; Unconditionally exit Evil-God state.
 (defun evil-god-state-bail ()
   "Stop current God command and exit God state."
   (interactive)
   (evil-stop-execute-in-god-state)
   (evil-god-stop-hook)
   (evil-normal-state))
-(evil-define-key 'god global-map [escape] 'evil-god-state-bail)
 
 (provide 'evil-god-state)
 ;;; evil-god-state.el ends here


### PR DESCRIPTION
Everyone I know who uses evil-god-state has had problems with getting stuck in it. Until we found the 'bail' code, we were ready to give up on evil-god-state. For that reason, I think it should be part of the base package.

Evil-god-state was aborting whenever I hit 'u' (for Ctrl-u).  This made prefix arguments impossible.  The trick is to detect when prefix arguments are being added and stay in evil-god-state.

With the command cycling change, Org Mode is easier to use with evil-god-state.  I leave <TAB> (Ctrl-i) for jumping forward, then use evil-god-state to run org-cycle with "SPC i".  But this only works if evil-god-state doesn't change the value of the 'last-command' variable.
