### PR TITLE
Fix support for universal arguments.

### DIFF
--- a/evil-god-state.el
+++ b/evil-god-state.el
@@ -78,13 +78,7 @@
 
 (defun evil-stop-execute-in-god-state ()
   "Switch back to previous evil state."
-  (unless (or (eq this-command #'evil-execute-in-god-state)
-              (eq this-command #'universal-argument)
-              (eq this-command #'universal-argument-minus)
-              (eq this-command #'universal-argument-more)
-              (eq this-command #'universal-argument-other-key)
-              (eq this-command #'digit-argument)
-              (eq this-command #'negative-argument)
+  (unless (or (eq real-this-command #'evil-execute-in-god-state)
               (minibufferp))
     (remove-hook 'pre-command-hook 'evil-god-fix-last-command)
     (remove-hook 'post-command-hook 'evil-stop-execute-in-god-state)


### PR DESCRIPTION
Fix for issue #5 

This PR fixes the following issue: if I temporarily enter God state using `evil-execute-in-god-state` then type a key bound to a prefix argument function (such as `digit-argument`), God state exits immediately. The prefix argument is duly recorded but I can't enter the rest of the command in God state.

The problem is the existing checks for prefix arguments (`(eq this-command #'digit-argument)` etc.)  were never evaluating to true because the prefix argument commands set the value of `this-command` to the value of `last-command`. So in a post-command hook we can't ever know via `this-command` whether a prefix argument has been applied.

This behavior of the prefix arg commands also points the way to a solution: since they also set `real-this-command` to the value of `real-last-command`, we can use `real-this-command` to know definitively whether `evil-execute-in-god-state` was the last command run _other than a prefix arg command_, which was the intent of the original checks.