### PR TITLE
Support wrapping `evil-execute-in-god-state'.

### DIFF
--- a/evil-god-state.el
+++ b/evil-god-state.el
@@ -72,13 +72,20 @@
 
 (defvar evil-god-last-command nil)
 
+(defvar evil-god-entry-command nil
+  "The command that was last used to enter God state.
+This variable is managed by `evil-execute-in-god-state', which
+ordinarily sets its value to `evil-execute-in-god-state'.  If another
+command wraps `evil-execute-in-god-state', then the value will be set
+to the name of that command instead.")
+
 (defun evil-god-fix-last-command ()
   "Change `last-command' to be the command before `evil-execute-in-god-state'."
   (setq last-command evil-god-last-command))
 
 (defun evil-stop-execute-in-god-state ()
   "Switch back to previous evil state."
-  (unless (or (eq this-command #'evil-execute-in-god-state)
+  (unless (or (eq this-command evil-god-entry-command)
               (eq this-command #'universal-argument)
               (eq this-command #'universal-argument-minus)
               (eq this-command #'universal-argument-more)
@@ -106,6 +113,7 @@
   (add-hook 'post-command-hook #'evil-stop-execute-in-god-state t)
   (setq evil-execute-in-god-state-buffer (current-buffer))
   (setq evil-god-last-command last-command)
+  (setq evil-god-entry-command this-command)
   (cond
    ((evil-visual-state-p)
     (let ((mrk (mark))


### PR DESCRIPTION
This PR makes it possible to wrap `evil-execute-in-god-state` in another command.

God state's post-command hook checks the name of the last-run command to know whether to exit the state. If I wrap `evil-execute-in-god-state` inside another command, the last-run command is no longer `evil-execute-in-god-state`, but rather the name of the command that wraps it. This would break the check as it currently exists. So I have simply updated `evil-execute-in-god-state` to set the name of the current command in a variable. The check now looks at this variable instead of hardcoding the command name.

I am currently using this feature to make normal-mode keybindings usable via God state. So I can have `,` bound to regular `evil-execute-in-god-state` and `'` bound to this:

    (defun evil-execute-in-god-state-with-evil-bindings ()
      (interactive)
      ;; evil-god-set-transient-bindings sets up an Evil intercept keymap
      ;; that makes the specified keybindings available in god state.
      ;; elsewhere i ensure the intercept map is cleaned up after leaving the state.
      (evil-god-set-transient-bindings
       (make-composed-keymap (current-active-maps)))
      (evil-execute-in-god-state))

Happy to share the full code for the above but it's dirty so not posting for the moment. Perhaps will make another PR for it later.