### PR TITLE
Fix docstring for `evil-god-start-hook'

### DIFF
--- a/evil-god-state.el
+++ b/evil-god-state.el
@@ -61,7 +61,7 @@
   :intercept-esc nil)
 
 (defun evil-god-start-hook ()
-  "Run before entering `evil-god-state'."
+  "Run after entering `evil-god-state'."
   (god-local-mode 1))
 
 (defun evil-god-stop-hook ()


### PR DESCRIPTION
I have verified through testing that the hook is called after entering `evil-god-state`, not before.